### PR TITLE
vercel 환경 변수 인식을 위한 수정

### DIFF
--- a/src/lib/supabaseClient.js
+++ b/src/lib/supabaseClient.js
@@ -1,4 +1,4 @@
 import { createClient } from '@supabase/auth-helpers-sveltekit'
-import { env } from '$env/dynamic/public'
+import { PUBLIC_SUPABASE_URL, PUBLIC_SUPABASE_ANON_KEY } from '$env/static/public'
 
-export const supabase = createClient(env.PUBLIC_SUPABASE_URL, env.PUBLIC_SUPABASE_ANON_KEY)
+export const supabase = createClient(PUBLIC_SUPABASE_URL, PUBLIC_SUPABASE_ANON_KEY)


### PR DESCRIPTION
환경 변수를 가져올때 svelte-kit은 dynamic과 static 방식을 지원하는데, dynamic 방식으로(자바스크립트 오브젝트/변수 형태로 갖고 있기) 로딩할때는 vercel이 제공하는 환경변수와 svelte-kit/vite 에서의 인식이 꼬이는것 같습니다.

https://kit.svelte.dev/docs/modules#$env-dynamic-public 과 아래에 static/public 관련 내용과 관련이 있을텐데, dynamic은 서버에서 클라로 env를 보내주는 형태라고 명시되어있는데, 아마도 svelte-kit의 자체 서버 로직이 작동하는한 (로컬에선 정상적인 이유) 우리에게 별 문제 없이 작동하지만, vercel에 배포했을 시 사실상 svelte-kit의 자체 서버라기보단 vercel의 serverless functions로 우리의 변형된 서버가 돌아가는 상황이 발생하며, vercel쪽에서 해당 방식으로 클라이언트에 env가 전송되는걸 막는건지, svelte-kit의 vercel adapter로 변형된 서버코드가 뭔가 꼬이는건지 둘중 하나겠지요?

다행히 해당 페이지를 읽어보시면, 꼭 필요한 경우를 제외하고는 dynamic(서버에서 보내주는 콜이 추가되는)이 아닌 static방식으로 로딩하라고 되어있습니다. static이라 함은, 사실상 자바스크립트 변수로 코드에 존재하는게 아니라, build되는 타이밍에 환경변수를 읽어서 코드 안에 해당 변수가 사용된 모든 영역을 읽어뒀던 환경변수로 내용을 바꿔버리는 형태입니다. webpack, rollup, vite등 번들러들을 통해 우리 코드가 빌딩이 되는 과정에서 하드코딩된 문자열로 대체해버리는거죠. 이런 형태의 처리는 개발모드/배포모드 등을 처리할때 활용하는 방식이기도 합니다.